### PR TITLE
if creating a fifo queue, set content dedup to be on by default

### DIFF
--- a/src/visitors/queues/index.js
+++ b/src/visitors/queues/index.js
@@ -76,6 +76,7 @@ module.exports = function visitQueues(arc, template) {
     let fifo = prop('fifo')
     if (fifo) {
       template.Resources[`${name}Queue`].Properties.FifoQueue = fifo
+      template.Resources[`${name}Queue`].Properties.ContentBasedDeduplication = true
     }
 
     template.Outputs[`${name}SqsQueue`] = {


### PR DESCRIPTION
this is so arc.functions.publish can avoid providing a MessageDeduplicationId. the options are to either:

- have arc.functions provide a `MessageDeduplicationId` when `publish`ing to a fifo queue, or
- set the queue to do Content-Based Deduplication by default

so i think it's either a pull request to this repo or to functions to fix this

more info at https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html\#FIFO-queues-exactly-once-processing

related: @brianleroux i noticed https://github.com/architect/package/blob/master/src/nested/base/queues.js#L6-L9 also has similar code, but doesn't include any logic around fifo nor sets fifo properties, like the code in the file i am changing in this PR does. should it? 
