### PR TITLE
Adds support for named indexes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [6.1.0] 2021-01-22
+
+### Added
+
+- Added support for `name` property in `@indexes` pragma to allow explicit naming of GSIs
+
+---
+
 ## [6.0.4] 2021-01-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/package",
-  "version": "6.0.4",
+  "version": "6.1.0",
   "description": "Package .arc for deployment with CloudFormation",
   "main": "src/index.js",
   "scripts": {

--- a/src/visitors/indexes/get-gsi-name.js
+++ b/src/visitors/indexes/get-gsi-name.js
@@ -1,8 +1,13 @@
 module.exports = function _getGsiName (index) {
-  let { name, partitionKey, partitionKeyType, sortKey } = index
+  let { indexName, name, partitionKey, partitionKeyType, sortKey } = index
   if (!partitionKey || !partitionKeyType) {
     throw Error(`Invalid @indexes: ${name}`)
   }
+
+  if (typeof indexName === 'string' && indexName.length > 0) {
+    return indexName
+  }
+
   let s = sortKey ? `-${sortKey}` : '' // Naming extension for multi-keys
   return `${partitionKey}${s}-index` // New school index naming
 }


### PR DESCRIPTION
A first pass at providing a solution for https://github.com/architect/architect/issues/974 which allows a custom index name to be provided as part of the @indexes declaration.
