### PR TITLE
Fixed issue where the static bucket url was wrong for newer AWS regions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ---
 
+## vNext
+
+### Fixed
+- Fixed issue where the static bucket url in the Cloudformation Output was wrong for newer AWS regions; thanks @thedersen
+
 ## [6.0.2] 2020-12-04
 
 ### Changed

--- a/src/visitors/static/index.js
+++ b/src/visitors/static/index.js
@@ -1,5 +1,24 @@
 let addStatic = require('./add-static-proxy')
 
+// See https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints
+function getBuckerUrlForRegion (region) {
+  let olderRegions = [
+    'us-east-1',
+    'us-west-1',
+    'us-west-2',
+    'us-gov-west-1',
+    'ap-southeast-1',
+    'ap-southeast-2',
+    'ap-northeast-1',
+    'sa-east-1',
+    'eu-west-1',
+  ]
+  if (olderRegions.includes(region)) {
+    return 'http://${bukkit}.s3-website-${AWS::Region}.amazonaws.com'
+  }
+  return 'http://${bukkit}.s3-website.${AWS::Region}.amazonaws.com'
+}
+
 /**
  * Visit arc.static and merge in AWS::Serverless resources
  */
@@ -24,7 +43,7 @@ module.exports = function visitStatic (inventory, template) {
     Description: 'Bucket URL',
     Value: {
       'Fn::Sub': [
-        'http://${bukkit}.s3-website-${AWS::Region}.amazonaws.com',
+        getBuckerUrlForRegion(inv.aws.region),
         { bukkit: { Ref: 'StaticBucket' } }
       ]
     }

--- a/src/visitors/static/index.js
+++ b/src/visitors/static/index.js
@@ -1,7 +1,7 @@
 let addStatic = require('./add-static-proxy')
 
 // See https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints
-function getBuckerUrlForRegion (region) {
+function getBucketUrlForRegion (region) {
   let olderRegions = [
     'us-east-1',
     'us-west-1',
@@ -43,7 +43,7 @@ module.exports = function visitStatic (inventory, template) {
     Description: 'Bucket URL',
     Value: {
       'Fn::Sub': [
-        getBuckerUrlForRegion(inv.aws.region),
+        getBucketUrlForRegion(inv.aws.region),
         { bukkit: { Ref: 'StaticBucket' } }
       ]
     }


### PR DESCRIPTION
Older AWS regions uses `http://${bukkit}.s3-website-${AWS::Region}.amazonaws.com` while newer uses `http://${bukkit}.s3-website.${AWS::Region}.amazonaws.com`

Notice the `.` vs `-` between s3-website and region in the url.
See https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints
