### PR TITLE
added helper method for `@plugins` authors `createLambdaJSON`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [6.2.0] 2021-03-02
+
+### Added
+
+- Added helper method `createLambdaJSON` for `@plugins` authors to help in defining CloudFormation-compatible Lambda definitions
+
+---
+
 ## [6.1.0] 2021-03-02
 
 ### Added

--- a/createLambdaJSON.js
+++ b/createLambdaJSON.js
@@ -1,0 +1,29 @@
+let { basename } = require('path')
+let { createLambda } = require('./src/visitors/utils')
+let read = require('@architect/inventory/src/read')
+let defaultFunctionConfig = require('@architect/inventory/src/defaults/function-config')
+let { toLogicalID } = require('@architect/utils')
+
+module.exports = function createLambdaJSON (inventory, src) {
+  let name = toLogicalID(basename(src))
+  let functionConfig = getFunctionConfig(src)
+  let functionDefinition = createLambda({
+    inventory,
+    lambda: {
+      src: src,
+      config: functionConfig
+    }
+  })
+  return [ `${name}PluginLambda`, functionDefinition ]
+}
+
+// compile any per-function config.arc customizations
+function getFunctionConfig (src) {
+  let defaults = defaultFunctionConfig()
+  let customizations = read({ type: 'functionConfig', cwd: src }).arc.aws
+  let overrides = {}
+  for (let config of customizations) {
+    overrides[config[0]] = config[1]
+  }
+  return { ...defaults, ...overrides }
+}

--- a/createLambdaJSON.js
+++ b/createLambdaJSON.js
@@ -4,7 +4,7 @@ let read = require('@architect/inventory/src/read')
 let defaultFunctionConfig = require('@architect/inventory/src/defaults/function-config')
 let { toLogicalID } = require('@architect/utils')
 
-module.exports = function createLambdaJSON (inventory, src) {
+module.exports = function createLambdaJSON ({ inventory, src }) {
   // clean up the path only for logical ID assembly
   // make sure it doesnt end with a slash
   let pathToCode = src.endsWith(sep) ? src.substr(0, src.length - 1) : src

--- a/createLambdaJSON.js
+++ b/createLambdaJSON.js
@@ -1,11 +1,20 @@
-let { basename } = require('path')
+let { sep } = require('path')
 let { createLambda } = require('./src/visitors/utils')
 let read = require('@architect/inventory/src/read')
 let defaultFunctionConfig = require('@architect/inventory/src/defaults/function-config')
 let { toLogicalID } = require('@architect/utils')
 
 module.exports = function createLambdaJSON (inventory, src) {
-  let name = toLogicalID(basename(src))
+  // clean up the path only for logical ID assembly
+  // make sure it doesnt end with a slash
+  let pathToCode = src.endsWith(sep) ? src.substr(0, src.length - 1) : src
+  pathToCode = pathToCode.
+    replace(process.cwd(), ''). // make it relative if it's absolute
+    replace(/^\.?\/?\\?/, ''). // axe if it starts with a dot or dot-slash
+    replace(/^src\/?\\?/, '') // remove the leading `src/`
+
+  // infer lambda based on source path
+  let name = toLogicalID(pathToCode)
   let functionConfig = getFunctionConfig(src)
   let functionDefinition = createLambda({
     inventory,

--- a/createLambdaJSON.js
+++ b/createLambdaJSON.js
@@ -20,7 +20,9 @@ module.exports = function createLambdaJSON (inventory, src) {
 // compile any per-function config.arc customizations
 function getFunctionConfig (src) {
   let defaults = defaultFunctionConfig()
-  let customizations = read({ type: 'functionConfig', cwd: src }).arc.aws
+  let customizations = []
+  let existingConfig = read({ type: 'functionConfig', cwd: src })
+  if (existingConfig.arc) customizations = existingConfig.arc.aws || []
   let overrides = {}
   for (let config of customizations) {
     overrides[config[0]] = config[1]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/package",
-  "version": "6.2.0-RC.0",
+  "version": "6.2.0-RC.1",
   "description": "Package .arc for deployment with CloudFormation",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/package",
-  "version": "6.1.0",
+  "version": "6.2.0-RC.0",
   "description": "Package .arc for deployment with CloudFormation",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,17 +21,17 @@
   "author": "Brian LeRoux <b@brian.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@architect/utils": "~2.0.4",
+    "@architect/utils": "~2.0.5-RC.0",
     "glob": "~7.1.6",
     "mime-types": "~2.1.28",
     "run-parallel": "~1.1.10"
   },
   "peerDependencies": {
-    "@architect/inventory": "^1.3.0-RC.0"
+    "@architect/inventory": "^1.3.0-RC.1"
   },
   "devDependencies": {
     "@architect/eslint-config": "1.0.0",
-    "@architect/inventory": "^1.3.0-RC.0",
+    "@architect/inventory": "^1.3.0-RC.1",
     "aws-sdk": "2.712.0",
     "codecov": "^3.8.1",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "run-parallel": "~1.1.10"
   },
   "peerDependencies": {
-    "@architect/inventory": "~1.2.2"
+    "@architect/inventory": "^1.3.0-RC.0"
   },
   "devDependencies": {
     "@architect/eslint-config": "1.0.0",
-    "@architect/inventory": "~1.2.3",
+    "@architect/inventory": "^1.3.0-RC.0",
     "aws-sdk": "2.712.0",
     "codecov": "^3.8.1",
     "cross-env": "^7.0.3",

--- a/test/unit/createlambdajson-test.js
+++ b/test/unit/createlambdajson-test.js
@@ -1,0 +1,47 @@
+let test = require('tape')
+let inventory = require('@architect/inventory')
+let json = require('../../createLambdaJSON')
+let mockFs = require('mock-fs')
+let fs = require('fs')
+let { join } = require('path')
+let base = fs.readFileSync(join(__dirname, '.arc-short')).toString()
+let inv
+
+test('Setup env', async t => {
+  t.plan(1)
+  inv = await inventory({ rawArc: base })
+  t.ok(inv, 'Inventory loaded')
+})
+
+test('createLambdaJSON should return a CFN definition with correct config.arc function configuration overrides', t => {
+  t.plan(1)
+  mockFs({
+    'src/lambda/one/config.arc': '@aws\nmemory 1337'
+  })
+  let result = json(inv, 'src/lambda/one')
+  mockFs.restore()
+  let defn = result[1]
+  t.equals(defn.Properties.MemorySize, 1337, 'Correct memory override read')
+})
+
+test('createLambdaJSON should return a properly formatted name based on the basename of the provided path to the function', t => {
+  t.plan(1)
+  mockFs({
+    'src/lambda/comb-the-desert/config.arc': '@aws\nmemory 1337'
+  })
+  let result = json(inv, 'src/lambda/comb-the-desert')
+  mockFs.restore()
+  let name = result[0]
+  t.equals(name, 'CombTheDesertPluginLambda', 'Lambda name is PascalCase and ends with PluginLambda')
+})
+
+test('createLambdaJSON should return a CFN definition with proper path', t => {
+  t.plan(1)
+  mockFs({
+    'src/lambda/beepboop/config.arc': '@aws\nmemory 1337'
+  })
+  let result = json(inv, 'src/lambda/beepboop')
+  mockFs.restore()
+  let defn = result[1]
+  t.equals(defn.Properties.CodeUri, 'src/lambda/beepboop', 'Correct CodeUri set based on local path')
+})

--- a/test/unit/createlambdajson-test.js
+++ b/test/unit/createlambdajson-test.js
@@ -54,5 +54,5 @@ test('createLambdaJSON should return a CFN definition with proper path', t => {
   let result = json(inv, join('src', 'lambda', 'beepboop'))
   mockFs.restore()
   let defn = result[1]
-  t.equals(defn.Properties.CodeUri, 'src/lambda/beepboop', 'Correct CodeUri set based on local path')
+  t.equals(defn.Properties.CodeUri, join('src', 'lambda', 'beepboop'), 'Correct CodeUri set based on local path')
 })

--- a/test/unit/createlambdajson-test.js
+++ b/test/unit/createlambdajson-test.js
@@ -1,15 +1,15 @@
 let test = require('tape')
-let inventory = require('@architect/inventory')
+let inv = require('@architect/inventory')
 let json = require('../../createLambdaJSON')
 let mockFs = require('mock-fs')
 let fs = require('fs')
 let { join } = require('path')
 let base = fs.readFileSync(join(__dirname, '.arc-short')).toString()
-let inv
+let inventory
 
 test('Setup env', async t => {
   t.plan(1)
-  inv = await inventory({ rawArc: base })
+  inventory = await inv({ rawArc: base })
   t.ok(inv, 'Inventory loaded')
 })
 
@@ -18,7 +18,7 @@ test('createLambdaJSON should return a CFN definition with correct config.arc fu
   mockFs({
     'src/lambda/one/config.arc': '@aws\nmemory 1337'
   })
-  let result = json(inv, join('src', 'lambda', 'one'))
+  let result = json({ inventory, src: join('src', 'lambda', 'one') })
   mockFs.restore()
   let defn = result[1]
   t.equals(defn.Properties.MemorySize, 1337, 'Correct memory override read')
@@ -29,7 +29,7 @@ test('createLambdaJSON should return a properly formatted name based on the prov
   mockFs({
     'src/lambda/comb-the-desert/config.arc': '@aws\nmemory 1337'
   })
-  let result = json(inv, join('src', 'lambda', 'comb-the-desert'))
+  let result = json({ inventory, src: join('src', 'lambda', 'comb-the-desert') })
   mockFs.restore()
   let name = result[0]
   t.equals(name, 'LambdaCombTheDesertPluginLambda', 'Lambda name is PascalCase, prefix is based on path after src/ and ends with PluginLambda')
@@ -40,7 +40,7 @@ test('createLambdaJSON should return a properly formatted name based on the prov
   mockFs({
     'src/timestream/dont-cross-them/config.arc': '@aws\nmemory 1337'
   })
-  let result = json(inv, join(process.cwd(), 'src', 'timestream', 'dont-cross-them'))
+  let result = json({ inventory, src: join(process.cwd(), 'src', 'timestream', 'dont-cross-them') })
   mockFs.restore()
   let name = result[0]
   t.equals(name, 'TimestreamDontCrossThemPluginLambda', 'Lambda name is PascalCase, prefix is based on path after src/ and ends with PluginLambda')
@@ -51,7 +51,7 @@ test('createLambdaJSON should return a CFN definition with proper path', t => {
   mockFs({
     'src/lambda/beepboop/config.arc': '@aws\nmemory 1337'
   })
-  let result = json(inv, join('src', 'lambda', 'beepboop'))
+  let result = json({ inventory, src: join('src', 'lambda', 'beepboop') })
   mockFs.restore()
   let defn = result[1]
   t.equals(defn.Properties.CodeUri, join('src', 'lambda', 'beepboop'), 'Correct CodeUri set based on local path')

--- a/test/unit/createlambdajson-test.js
+++ b/test/unit/createlambdajson-test.js
@@ -18,21 +18,32 @@ test('createLambdaJSON should return a CFN definition with correct config.arc fu
   mockFs({
     'src/lambda/one/config.arc': '@aws\nmemory 1337'
   })
-  let result = json(inv, 'src/lambda/one')
+  let result = json(inv, join('src', 'lambda', 'one'))
   mockFs.restore()
   let defn = result[1]
   t.equals(defn.Properties.MemorySize, 1337, 'Correct memory override read')
 })
 
-test('createLambdaJSON should return a properly formatted name based on the basename of the provided path to the function', t => {
+test('createLambdaJSON should return a properly formatted name based on the provided path to the function', t => {
   t.plan(1)
   mockFs({
     'src/lambda/comb-the-desert/config.arc': '@aws\nmemory 1337'
   })
-  let result = json(inv, 'src/lambda/comb-the-desert')
+  let result = json(inv, join('src', 'lambda', 'comb-the-desert'))
   mockFs.restore()
   let name = result[0]
-  t.equals(name, 'CombTheDesertPluginLambda', 'Lambda name is PascalCase and ends with PluginLambda')
+  t.equals(name, 'LambdaCombTheDesertPluginLambda', 'Lambda name is PascalCase, prefix is based on path after src/ and ends with PluginLambda')
+})
+
+test('createLambdaJSON should return a properly formatted name based on the provided path to the function (even if path is absolute)', t => {
+  t.plan(1)
+  mockFs({
+    'src/timestream/dont-cross-them/config.arc': '@aws\nmemory 1337'
+  })
+  let result = json(inv, join(process.cwd(), 'src', 'timestream', 'dont-cross-them'))
+  mockFs.restore()
+  let name = result[0]
+  t.equals(name, 'TimestreamDontCrossThemPluginLambda', 'Lambda name is PascalCase, prefix is based on path after src/ and ends with PluginLambda')
 })
 
 test('createLambdaJSON should return a CFN definition with proper path', t => {
@@ -40,7 +51,7 @@ test('createLambdaJSON should return a CFN definition with proper path', t => {
   mockFs({
     'src/lambda/beepboop/config.arc': '@aws\nmemory 1337'
   })
-  let result = json(inv, 'src/lambda/beepboop')
+  let result = json(inv, join('src', 'lambda', 'beepboop'))
   mockFs.restore()
   let defn = result[1]
   t.equals(defn.Properties.CodeUri, 'src/lambda/beepboop', 'Correct CodeUri set based on local path')


### PR DESCRIPTION
plugins can define new lambdas, and in order to ease augmentation of CloudFormation JSON, a new `createLambdaJSON` helper method is provided for plugin authors as part of this `package` module. This method returns both:

1. a CFN JSON definition for a Lambda (based on how `package` already compiles this for built-in architect pragmas leveraging Lambdas)
2. an architect-compatible Lambda name (important as `logs` relies on a specific Lambda naming scheme in order to retrieve CloudWatch logs for them)

TODO:

- [x] `let name = toLogicalID(basename(src))` should use more than the basename, should use everything after `src/`, i.e. matches how `architect/logs` determines the lambda name.

Setting this as a draft PR until all the other PRs for the other core arc packages are ready as well.

Relevant content:

- The Plugin Authoring docs PR is here: architect/arc.codes#324
- The original RFC is here: architect/architect#1062