### PR TITLE
move plugin helper createLambdaJSON to export module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [6.2.1] 2021-04-23
+
+### Added
+
+- Moved and renamed helper method `createFunction` (formerly `createLambdaJSON`) for `@plugins` authors as export on main module export, it is now available at `require('@architect/package').createFunction`
+
+---
+
 ## [6.2.0] 2021-03-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@architect/eslint-config": "1.0.0",
-    "@architect/inventory": "^1.3.1",
+    "@architect/inventory": "^1.3.3-RC.0",
     "aws-sdk": "2.712.0",
     "codecov": "^3.8.1",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@architect/eslint-config": "1.0.0",
-    "@architect/inventory": "^1.3.3-RC.0",
+    "@architect/inventory": "^1.3.3",
     "aws-sdk": "2.712.0",
     "codecov": "^3.8.1",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/package",
-  "version": "6.2.0",
+  "version": "6.2.1-RC.0",
   "description": "Package .arc for deployment with CloudFormation",
   "main": "src/index.js",
   "scripts": {

--- a/src/create-function.js
+++ b/src/create-function.js
@@ -1,10 +1,11 @@
 let { sep } = require('path')
-let { createLambda } = require('./src/visitors/utils')
+let { createLambda } = require('./visitors/utils')
 let read = require('@architect/inventory/src/read')
 let defaultFunctionConfig = require('@architect/inventory/src/defaults/function-config')
 let { toLogicalID } = require('@architect/utils')
 
-module.exports = function createLambdaJSON ({ inventory, src }) {
+// this module is for plugin authors use when creating new AWS::Serverless::Function CloudFormation Resource entries
+module.exports = function createFunction ({ inventory, src }) {
   // clean up the path only for logical ID assembly
   // make sure it doesnt end with a slash
   let pathToCode = src.endsWith(sep) ? src.substr(0, src.length - 1) : src

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 let { version } = require('../package.json')
 let visitors = require('./visitors')
+let createFunctions = require('./create-function')
 
 /**
  * Architect Package
@@ -47,3 +48,5 @@ module.exports = function package (inventory) {
   // walk pragmas to reduce final template contents
   return pragmas.reduce(visit, template)
 }
+
+module.exports.createFunction = createFunctions

--- a/test/unit/create-function-test.js
+++ b/test/unit/create-function-test.js
@@ -1,7 +1,7 @@
 let test = require('tape')
 let mockFs = require('mock-fs')
 let inv = require('@architect/inventory')
-let json = require('../../createLambdaJSON')
+let json = require('../../src/create-function')
 let fs = require('fs')
 let { join } = require('path')
 let base = fs.readFileSync(join(__dirname, '.arc-short')).toString()


### PR DESCRIPTION
Moving `createLambdaJSON` off of a path-based require and onto the exported `package` module.

Not sure about the version bump; should it be minor? Major? Patch?