### PR TITLE
Use https, not http, for API Gateway proxy to static bucket

### DIFF
--- a/src/visitors/static/add-static-proxy.js
+++ b/src/visitors/static/add-static-proxy.js
@@ -7,7 +7,7 @@ module.exports = function addStatic (inventory, template) {
         httpMethod: 'GET',
         uri: {
           'Fn::Sub': [
-            'http://${bukkit}.s3.${AWS::Region}.amazonaws.com/{proxy}',
+            'https://${bukkit}.s3.${AWS::Region}.amazonaws.com/{proxy}',
             { bukkit: { Ref: 'StaticBucket' } }
           ]
         },


### PR DESCRIPTION
According to AWS Support, an API Gateway that proxies a path to an S3 bucket using an http URL is vulnerable to man-in-the-middle attacks, just like any non-TLS http transfer over the Internet.

S3 static web site URLs support only http, not https. AWS Support recommends using a CloudFront distribution to add TLS termination to S3 bucket access. However, a simpler approach is to simply proxy to the S3 REST API endpoint, which does support https.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
