### PR TITLE
update eslint and fix valid-typeof

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@architect/eslint-config": "~2.0.1",
     "aws-sdk": "2.1001.0",
     "cross-env": "^7.0.3",
-    "eslint": "^8.9.0",
+    "eslint": "^8.11.0",
     "mock-fs": "~5.1.2",
     "nyc": "^15.1.0",
     "run-parallel": "~1.2.0",

--- a/src/visitors/utils/get-lambda-env.js
+++ b/src/visitors/utils/get-lambda-env.js
@@ -36,7 +36,7 @@ module.exports = function getEnv (params) {
 
       // SPA defaults to false if env var isn't set
       let spaSetting = get.static('spa')
-      let hasSpa = typeof spaSetting !== undefined
+      let hasSpa = typeof spaSetting !== 'undefined'
       if (hasSpa) env.ARC_STATIC_SPA = spaSetting
     }
   }


### PR DESCRIPTION
`eslint` 8.9 resolves to 8.11 now and it seems eslint added or fixed something that enforces the valid-typeof rule.

I believe the assumption that "undefined" should be a string in the changed line is correct since `typeof` could never result in literal `undefined`.
@ryanblock can you check my assumption?