### PR TITLE
Fix unexpanded substitution in ArcDynamoPolicy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ---
 
+## [8.1.2] unreleased
+
+- Fixed a CloudFormation syntax error that was introduced in 8.1.1.
+
 ## [8.1.1] 2022-04-28
 
 ### Added

--- a/src/visitors/globals/index.js
+++ b/src/visitors/globals/index.js
@@ -89,7 +89,9 @@ module.exports = function visitGlobals (inventory, template) {
           {
             Effect: 'Deny',
             Action: 'dynamodb:DeleteTable',
-            Resource: 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*',
+            Resource: {
+              'Fn::Sub': 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*',
+            },
           },
         ]
       }


### PR DESCRIPTION
#152 introduced a syntax error of the kind described in https://stackoverflow.com/a/51728883/167694 that caused deployment of the CloudFormation stack to fail with this kind of error message:

    The policy failed legacy parsing (Service: AmazonIdentityManagement; Status Code: 400; Error Code: MalformedPolicyDocument; Request ID: ...; Proxy: null)

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
