### PR TITLE
Add option to control AWS Lambda provisioned concurrency

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 ---
 
+## [8.2.0] unreleased
+
+### Added
+
+- Add `provisionedConcurrency` project manifest option to configure AWS Lambda
+  provisioned concurrency, which can reduce latency by avoiding cold starts.
+  For more information, see: https://docs.aws.amazon.com/lambda/latest/dg/provisioned-concurrency.html
+
+---
+
 ## [8.1.5] 2022-09-07
 
 ### Changed

--- a/src/visitors/http/get-api-properties.js
+++ b/src/visitors/http/get-api-properties.js
@@ -22,7 +22,7 @@ function getPaths (routes, payloadFormatVersion) {
   let paths = {}
 
   routes.forEach(route => {
-    let { method, path } = route
+    let { method, path, config: { provisionedConcurrency } } = route
     // Special API Gateway OpenAPI impl for `any` method
     let m = method === 'any' ? 'x-amazon-apigateway-any-method' : method
     let cfPath = renderRoute(path)
@@ -33,7 +33,7 @@ function getPaths (routes, payloadFormatVersion) {
           payloadFormatVersion,
           type: 'aws_proxy',
           httpMethod: 'POST',
-          uri: getURI({ path, method }),
+          uri: getURI({ path, method, provisionedConcurrency }),
           connectionType: 'INTERNET',
           // TODO currently ignored, reimplement when respected by HTTP APIs
           // cacheNamespace: xlr8r,
@@ -53,6 +53,7 @@ let getName = ({ path, method }) => toLogicalID(`${method}${getLambdaName(path).
 
 function getURI (route) {
   let name = getName(route)
-  let arn = `arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${${name}HTTPLambda.Arn}/invocations`
+  let alias = route.provisionedConcurrency ? ':live' : ''
+  let arn = `arn:aws:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${${name}HTTPLambda.Arn}${alias}/invocations`
   return { 'Fn::Sub': arn }
 }

--- a/src/visitors/utils/create-lambda.js
+++ b/src/visitors/utils/create-lambda.js
@@ -3,7 +3,7 @@ let getLambdaEnv = require('./get-lambda-env')
 module.exports = function createLambda (params) {
   let { lambda, inventory, template } = params
   let { build, src, config } = lambda
-  let { architecture, timeout, memory, runtime, storage, runtimeConfig, handler, concurrency, layers, policies } = config
+  let { architecture, timeout, memory, runtime, storage, runtimeConfig, handler, concurrency, provisionedConcurrency, layers, policies } = config
   let Variables = getLambdaEnv({ config, inventory, lambda, runtime })
   let Runtime = runtimeConfig?.baseRuntime || runtime
 
@@ -31,6 +31,13 @@ module.exports = function createLambda (params) {
 
   if (concurrency !== 'unthrottled') {
     item.Properties.ReservedConcurrentExecutions = concurrency
+  }
+
+  if (provisionedConcurrency) {
+    item.Properties.ProvisionedConcurrencyConfig = {
+      ProvisionedConcurrentExecutions: provisionedConcurrency
+    }
+    item.Properties.AutoPublishAlias = 'live'
   }
 
   if (layers.length > 0) {


### PR DESCRIPTION
Provisioned concurrency decreases latency by reducing the chances that a user will experience e an AWS Lambda cold start. Add an option to control provisioned concurrency.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
