### PR TITLE
Bugfix: The resource name for the HTTP Event AWS generates contains the lambda name twice

### DIFF
--- a/src/visitors/http/index.js
+++ b/src/visitors/http/index.js
@@ -30,7 +30,7 @@ module.exports = function visitHttp (inventory, template) {
     let lambdaName = getLambdaName(route.path)
     let name = toLogicalID(`${method}${lambdaName.replace(/000/g, '')}`) // GetIndex
     let routeLambda = `${name}HTTPLambda`
-    let routeEvent = `${name}HTTPEvent`
+    let routeEvent = 'HTTPEvent' //AWS appends the lambda name
 
     // Create the Lambda
     template.Resources[routeLambda] = createLambda({


### PR DESCRIPTION
During the deployment, AWS first creates the new resource and the deletes the old one. Therefore, this fix does not cause any sort of downtime. It should also be backwards compatible, unless someone relies on the HTTP event name schema while overriding the cloudformation template in the `deploy.start` hook.

This fixes https://github.com/architect/architect/issues/1487

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
